### PR TITLE
Use the original URL when requests are forwarded

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -134,11 +134,10 @@ async function handleRequest(event: FetchEvent): Promise<Response> {
   let url: string = request.url
   let response: Response
 
-  // If the request URL includes forward=true we avoid fetching the upstream URL, instead we reply
-  // directly with an OK status. Additionally we try to get the original URL from the x-original-url
-  // header.
-  // We use a custom header to change as little as possible from the original request.
-  if (request.url.includes('forward=true')) {
+  // If the request contains a 'x-original-url' header we understand that this request is forwarded
+  // to the worker and that therefor the upstream should not be fetched. We use a custom header to
+  // change as little as possible from the original request.
+  if (request.headers.get('x-original-url') != null) {
     response = new Response('ok', { status: 200 })
     url = request.headers.get('x-original-url') || request.url
   } else {

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -131,15 +131,13 @@ async function handleRequest(event: FetchEvent): Promise<Response> {
     currentHost = request.headers.get('host') || request.headers.get('hostname')
   }
 
-  let url: string = request.url
   let response: Response
-
+  let url = request.headers.get('x-original-url') || request.url
   // If the request contains a 'x-original-url' header we understand that this request is forwarded
   // to the worker and that therefor the upstream should not be fetched. We use a custom header to
   // change as little as possible from the original request.
   if (request.headers.get('x-original-url') != null) {
     response = new Response('ok', { status: 200 })
-    url = request.headers.get('x-original-url') || request.url
   } else {
     // fetch the original request
     console.log(`Fetching origin ${request.url}`)

--- a/test/handler.ts
+++ b/test/handler.ts
@@ -8,10 +8,10 @@ describe('request handler', () => {
 
   it('sends payload to storage', async () => {
     const headers: HeadersInit = new Headers({
+      host: 'some.google.host',
       'x-forwarded-proto': 'https',
       'cf-ipcountry': 'US',
       'cf-connecting-ip': '17.110.220.180',
-      host: 'some.google.host',
       'user-agent':
         'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/601.3.9 (KHTML, like Gecko) Version/9.0.2 Safari/601.3.9',
     })
@@ -41,10 +41,10 @@ describe('request handler', () => {
 
   it('avoid fetching upstream when the URL is forwarded', async () => {
     const headers: HeadersInit = new Headers({
+      host: 'dashflare.test.workers.dev',
       'x-forwarded-proto': 'https',
       'cf-ipcountry': 'US',
       'cf-connecting-ip': '17.110.220.180',
-      host: 'dashflare.test.workers.dev',
       'user-agent':
         'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/601.3.9 (KHTML, like Gecko) Version/9.0.2 Safari/601.3.9',
       'x-original-url': 'https://example.com',

--- a/test/handler.ts
+++ b/test/handler.ts
@@ -52,7 +52,7 @@ describe('request handler', () => {
     })
 
     const event = new FetchEvent('fetch', {
-      request: new Request('https://dashflare.test.workers.dev?forward=true', {
+      request: new Request('https://dashflare.test.workers.dev', {
         headers,
       }),
     })


### PR DESCRIPTION
When the request is forwarded to the edge worker instead of running as a transparent proxy (via the routes) the original URL gets lost. This PR defines a new custom header `x-original-url` for passing the original URL around. If the request is forwarded and the header is found it will be used to extract the `domain`, `path`, `query` for the logging of the visit.

Since the new request should be initialized using the original request, all headers should be passed down to the edge worker, so the referer parsing should still continue to work and not be lost in the process. The new header needs to be manually added to the outgoing request:

```typescript
let req = new Request('https://dashflare.test.workers.dev', origReq);
req.headers.append('x-original-url', origReq.url)
```

This is especially relevant for integrations with Cloudflare's Worker Sites because it is not possible to set multiple workers on the same route.


FYI @mre 