### PR TITLE
worker: Extract the referer's domain

### DIFF
--- a/test/handler.ts
+++ b/test/handler.ts
@@ -69,6 +69,7 @@ describe('request handler', () => {
         // the referer of the original request is detected and parsed
         'network=twitter',
         'type=social',
+        'referer_domain=t.co',
       ].every((bit) => string.includes(bit)),
     )
   })


### PR DESCRIPTION
When looking at the traffic source, it is important to not just know if it is internal/social or direct, but also from where it is coming from. The exact referrer is extracted and stored but for visualization in the dashboard (and even for running queries)  having the domain is preferred.

This should by particularly useful for not social/big referrer sources.