### PR TITLE
Add a partial development environment with nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -13,6 +13,6 @@ pkgs.stdenv.mkDerivation {
 
     shellHook = ''
         export PATH="$PWD/node_modules/.bin/:$PATH"
-        alias run='npm run'
+        alias dev='wrangler dev --env=dev'
     '';
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,18 @@
+let
+  pkgs = import <nixpkgs> {};
+in
+
+pkgs.stdenv.mkDerivation {
+  name = "dashflareio";
+
+  buildInputs =
+    [
+      pkgs.nodejs
+      pkgs.wrangler
+    ];
+
+    shellHook = ''
+        export PATH="$PWD/node_modules/.bin/:$PATH"
+        alias run='npm run'
+    '';
+}


### PR DESCRIPTION
We have two hard dependencies for having a development environment
capable of building the worker contained in this repo. We now allow to
install both dependencies (npm, wrangler) via nix-shell this
makes having a reproducible dev environment easier.