### PR TITLE
Remove duplicated data from the labels. Add individual tests for payload and labels

### DIFF
--- a/test/handler.ts
+++ b/test/handler.ts
@@ -38,6 +38,7 @@ describe('request handler', () => {
     var bodyObj: StoragePayload
     bodyObj = JSON.parse(body.toString())
 
+    // validate the payload (log line)
     expect(bodyObj.streams[0].entries[0].line).to.satisfy((string) =>
       [
         'os="Mac OS"',
@@ -48,9 +49,24 @@ describe('request handler', () => {
         'method=GET',
         'status=200',
         'domain=example.com',
+        'url=http://example.com/',
       ].every((bit) => string.includes(bit)),
     )
     expect(bodyObj.streams[0].entries[0].line).to.not.include('17.110.220.180')
+
+    // validate the label set (identifies the stream)
+    expect(bodyObj.streams[0].labels).to.satisfy((string) =>
+      [
+        'device_type="desktop"',
+        'method="GET"',
+        'status="200"',
+        'protocol="https"',
+      ].every((bit) => string.includes(bit)),
+    )
+
+    expect(bodyObj.streams[0].labels).to.not.include('url')
+    expect(bodyObj.streams[0].labels).to.not.include('geohash')
+    expect(bodyObj.streams[0].labels).to.not.include('origin')
   })
 
   it('avoid fetching upstream when the URL is forwarded', async () => {


### PR DESCRIPTION
This PR is a bit larger than usual. It includes a dynamic testing interface (`StoragePayload`) for allowing advanced inspection of the payload sent to Grafana Loki.

We remove a lot of duplicated information from the labels (see #17) and also fixes #20 (with the new testing interface we can write independent assertions for the labels or payload).

A small refactor (as part of #20) is also included which makes it easier to track which information is included in the `LabelSet`.