### PR TITLE
Rename IPINFO_TOKEN to IPINFO

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -19,8 +19,6 @@ const JAVASCRIPT_REGEX = /\.js/
 const IMAGE_REGEX = /\.(?:png|jpg|jpeg|webp|gif|ico|svg|webmanifest)/
 const CSS_REGEX = /\.css/
 
-// Used in a different file but also should be configurable
-// IPINFO_TOKEN
 const LOKI_URL = `http://${LOKI_HOST}/api/prom/push`
 
 const EXCLUDE = JSON.parse(OPTIONS) || {
@@ -84,6 +82,7 @@ async function flushQueue() {
   )
 
   obj['level'] = levelFromStatus(status)
+  obj['session'] = session
 
   let payload = {
     streams: [

--- a/src/ipinfo.ts
+++ b/src/ipinfo.ts
@@ -22,12 +22,9 @@ function toGeoData(res: Promise<Hash<any>>): Promise<IGeoData> {
 }
 
 async function ipInfo(ip: string): Promise<IGeoData> {
-  // If the IPINFO_TOKEN variable is empty we asssume that the geolocation has been disabled by the
+  // If the IPINFO variable is empty we assume that the geolocation has been disabled by the
   // user and avoid requesting any info from the API
-  if (
-    IPINFO_TOKEN.trim().length === 0 ||
-    IPINFO_TOKEN.trim().toLowerCase() == 'false'
-  ) {
+  if (IPINFO.trim().length === 0 || IPINFO.trim().toLowerCase() == 'false') {
     return <IGeoData>{}
   }
 
@@ -46,7 +43,7 @@ async function ipInfo(ip: string): Promise<IGeoData> {
   }
 
   const res = await fetch(url)
-  // ince in this case we can predict the size of the payload (which it is not large)
+  // in this case we can predict the size of the payload (which it is not large)
   // we're going for the pragmatic solution of reading the entire body both in production
   // and testing.
   // see https://github.com/zackargyle/service-workers/issues/135

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -8,7 +8,7 @@ declare global {
   }
 
   // The token is provided by cloudflare workers automatically from the secrets
-  let IPINFO_TOKEN: string
+  let IPINFO: string
 
   // The client id
   let CLIENT_ID: string

--- a/test/_setup.ts
+++ b/test/_setup.ts
@@ -7,7 +7,7 @@ declare global {
   }
 
   // The token is provided by cloudflare workers automatically from the secrets
-  let IPINFO_TOKEN: string
+  let IPINFO: string
 
   // The client id
   let CLIENT_ID: string
@@ -25,7 +25,7 @@ declare global {
 }
 
 var DEFAULT_OPTIONS = {
-  IPINFO_TOKEN: 'test-token',
+  IPINFO: 'test-token',
   CLIENT_ID: 'client-id',
   LOKI_HOST: 'loki:3100',
   FINGERPRINT: 'some-uuid',

--- a/test/ipinfo.ts
+++ b/test/ipinfo.ts
@@ -102,14 +102,14 @@ describe('enabled geolocation', async () => {
 
 describe('disabled geolocation', async () => {
   after(() => fetchMock.restore())
-  let oldToken = IPINFO_TOKEN
+  let oldToken = IPINFO
 
   before(() => {
-    IPINFO_TOKEN = ''
+    IPINFO = ''
   })
 
   after(() => {
-    IPINFO_TOKEN = oldToken
+    IPINFO = oldToken
   })
 
   it('empty result', async () => {
@@ -120,9 +120,9 @@ describe('disabled geolocation', async () => {
   })
 
   it('disabled via false', async () => {
-    IPINFO_TOKEN = 'false'
+    IPINFO = 'false'
     let res = await ipInfo('17.110.220.180')
-    IPINFO_TOKEN = ''
+    IPINFO = ''
     expect(res).to.be.empty
     expect(fetchMock.calls()).to.be.empty
   })

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -36,7 +36,7 @@ module.exports = {
   mode,
   plugins: [
     new webpack.DefinePlugin({
-      IPINFO_TOKEN: ipInfoToken,
+      IPINFO: ipInfoToken,
       CLIENT_ID: clientId,
       LOKI_HOST: lokiHost,
       OPTIONS: `'${excludeOptions}'`,

--- a/wrangler.toml.template
+++ b/wrangler.toml.template
@@ -3,7 +3,7 @@ type = "webpack"
 workers_dev = false
 route = ""
 webpack_config = "webpack.config.js"
-vars = { OPTIONS = '{"css":true,"images":true,"js":true,"ip":true}', LOKI_HOST="$LOKI_HOST", CLIENT_ID="$CLIENT_ID", IPINFO_TOKEN="$IPINFO", FINGERPRINT="$FINGERPRINT" }
+vars = { OPTIONS = '{"css":true,"images":true,"js":true,"ip":true}', LOKI_HOST="$LOKI_HOST", CLIENT_ID="$CLIENT_ID", IPINFO="$IPINFO", FINGERPRINT="$FINGERPRINT" }
 
 routes = [
     "$DOMAIN/*",


### PR DESCRIPTION
Since we switched geolocation providers a while back we no longer need a
token, we can either use the public available instance or self-host a
private instance but in either of those cases a token is no longer
needed. Nevertheless, we keep the environment variable around as a way
of fully opting out of any geolocation of the users.

Closes #5 